### PR TITLE
feat: DivisionId in GetMatchResponse

### DIFF
--- a/tabt.wsdl
+++ b/tabt.wsdl
@@ -355,6 +355,7 @@
       <xsd:complexType name="TeamMatchEntryType">
         <xsd:all>
           <xsd:element name="DivisionName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+          <xsd:element name="DivisionId" minOccurs="1" maxOccurs="1" type="xsd:integer"/>
           <xsd:element name="MatchId" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="WeekName" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="Date" minOccurs="0" maxOccurs="1" type="xsd:date"/>

--- a/tabtapi.php
+++ b/tabtapi.php
@@ -710,7 +710,8 @@ EOQ;
     if ($WithDetails) {
       $resDetails = array(
         'DetailsCreated' => $db->Record['MatchUniqueId']>0,
-        'MatchSystem'    => $db->Record['MatchTypeId']
+        'MatchSystem'    => $db->Record['MatchTypeId'],
+        'DivisionId'     => $db->Record['DivisionId']
       );
       if ($db->Record['HomeCaptain']) {
         $resDetails['HomeCaptain'] = intval($db->Record['HomeCaptain']);


### PR DESCRIPTION
I need to receive the DivisionId from GetMatch to remove a bug in BePing. 
Without this I can't redirect reliably from a page you see results to a page with a division ranking.