### PR TITLE
Return more info in GetMembers

### DIFF
--- a/tabt.wsdl
+++ b/tabt.wsdl
@@ -407,7 +407,7 @@
           <xsd:element name="LastName" type="xsd:string"/>
           <xsd:element name="Ranking" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="Status" minOccurs="0" maxOccurs="1" type="xsd:string"/>
-          <xsd:element name="Club" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+          <xsd:element name="Club" type="xsd:string"/>
           <xsd:element name="Gender" minOccurs="0" maxOccurs="1" type="tns:GenderType"/>
           <xsd:element name="Category" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="BirthDate" minOccurs="0" maxOccurs="1" type="xsd:date"/>

--- a/tabt.wsdl
+++ b/tabt.wsdl
@@ -369,7 +369,7 @@
           <xsd:element name="AwayTeam" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="Score" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="MatchUniqueId" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
-          <xsd:element name="NextWeekName" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
+          <xsd:element name="NextWeekName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="PreviousWeekName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="IsHomeForfeited" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
           <xsd:element name="IsAwayForfeited" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>

--- a/tabt.wsdl
+++ b/tabt.wsdl
@@ -369,7 +369,7 @@
           <xsd:element name="AwayTeam" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="Score" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="MatchUniqueId" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
-          <xsd:element name="NextWeekName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+          <xsd:element name="NextWeekName" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
           <xsd:element name="PreviousWeekName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="IsHomeForfeited" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
           <xsd:element name="IsAwayForfeited" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
@@ -551,6 +551,7 @@
           <xsd:element name="CompetitionType" type="tns:CompetitionType"/>
           <xsd:element name="Club" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="MatchId" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+          <xsd:element name="MatchUniqueId" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
           <xsd:element name="TournamentName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="TournamentSerieName" minOccurs="0" maxOccurs="1" type="xsd:string"/>
           <xsd:element name="TeamName" minOccurs="0" maxOccurs="1" type="xsd:string"/>

--- a/tabtapi.php
+++ b/tabtapi.php
@@ -1414,6 +1414,7 @@ EOQ;
         }
         if ($current_result['CompetitionType'] == 'C') {
           $current_result['MatchId'] = $result[14];
+          $current_result['MatchUniqueId'] = $result[8]; 
         }
         if (strlen($result[15]) > 0) {
           $OppRankingEvaluationEntries = array();

--- a/tabtapi.php
+++ b/tabtapi.php
@@ -1323,13 +1323,10 @@ EOQ;
         'FirstName' => $db->Record['first_name'],
         'LastName'  => $db->Record['last_name'],
         'Ranking'   => $db->Record['classement'],
-        'Status'    => $db->Record['status']
+        'Status'    => $db->Record['status'],
+        'Club'      => $db->Record['club_indice']
       )
     );
-    if ($Club=='')
-    {
-      $entry['Club'] = $db->Record['club_indice'];
-    }
     if ($ExtendedInformation)
     {
       $entry['Gender']             = $db->Record['sex'];


### PR DESCRIPTION
This PR adds more details in the response of GetMembers. It will include:
- Always add the club index in MemberEntries
- Add MatchUniqueId in ResultEntries

This is useful for my backend application that needs to make links between matchs/members 